### PR TITLE
chore: fix the preview build

### DIFF
--- a/preview_build/requirements.txt
+++ b/preview_build/requirements.txt
@@ -1,4 +1,9 @@
 Sphinx==4.4.0
 sphinx-autobuild==2021.3.14
 urllib3==1.26.6
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 docs-italia-theme @ git+https://github.com/italia/docs-italia-theme.git@7bfccf507a7520b5fed5eda4b5c51c1f9d45ad88

--- a/preview_build/requirements.txt
+++ b/preview_build/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==4.4.0
 sphinx-autobuild==2021.3.14
+urllib3==1.26.6
 docs-italia-theme @ git+https://github.com/italia/docs-italia-theme.git@7bfccf507a7520b5fed5eda4b5c51c1f9d45ad88


### PR DESCRIPTION
The preview build fails because of
https://github.com/readthedocs/readthedocs.org/issues/10290, let's pin urllib3 to workaround that.

cc @danielenole @Fupete 